### PR TITLE
Enable Centrifugo

### DIFF
--- a/backend/src/Service/Centrifugo.php
+++ b/backend/src/Service/Centrifugo.php
@@ -19,7 +19,7 @@ final class Centrifugo
 
     public function isSupported(): bool
     {
-        return $this->environment->isDocker() && !$this->environment->isTesting();
+        return !$this->environment->isTesting();
     }
 
     public function publishToStation(Station $station, mixed $message, array $triggers): void


### PR DESCRIPTION
No reason for checking whether we're running inside docker.  I believe it was there for legacy reasons when Ansible was still supported but haven't adapted Centrifugo.  Well, now the current Ansible doesn't work at all regardless of Centrifugo, but the soon to be resurrected Ansible, does support Centrifugo :)